### PR TITLE
Use CharacterSet of Swift and use property setting with closure

### DIFF
--- a/Sources/String+ImgixSwift.swift
+++ b/Sources/String+ImgixSwift.swift
@@ -9,13 +9,12 @@
 import Foundation
 
 extension String {
-    static var ixEncodeUriComponentCharSet: NSMutableCharacterSet {
-        let cs = NSMutableCharacterSet.alphanumeric()
-        cs.addCharacters(in: "-_.!~*'()")
-        
+    static var ixEncodeUriComponentCharSet: CharacterSet = {
+        var cs = CharacterSet.alphanumerics
+        cs.insert(charactersIn: "-_.!~*'()")
         return cs
-    }
-    
+    }()
+
     func ixEncode64() -> String {
         let strData = self.data(using: String.Encoding.utf8)
         
@@ -31,6 +30,6 @@ extension String {
     }
     
     func ixEncodeUriComponent() -> String {
-        return self.addingPercentEncoding(withAllowedCharacters: String.ixEncodeUriComponentCharSet as CharacterSet)!
+        return self.addingPercentEncoding(withAllowedCharacters: String.ixEncodeUriComponentCharSet)!
     }
 }


### PR DESCRIPTION
- Declare `ixEncodeUriComponentCharSet` as a CharacterSet.
- Declare `ixEncodeUriComponentCharSet` with property setting with closure instead of computed property to avoid `addCharacters(in:)` which is slightly heavy and no need called every time when buildUrl(_:params:) called.

<img width="1036" alt="screen shot 2018-08-30 at 16 20 52" src="https://user-images.githubusercontent.com/1997960/44836096-fd40d800-ac70-11e8-87ac-6445ba1c486c.png">