### PR TITLE
Sort query parameters

### DIFF
--- a/ImgixSwiftTests/BuildUrlTests.swift
+++ b/ImgixSwiftTests/BuildUrlTests.swift
@@ -50,14 +50,14 @@ class BuildUrlTests: XCTestCase {
         client.includeLibraryParam = true
         
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 400])
-        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?w=400&ixlib=swift-" + ImgixClient.VERSION
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?ixlib=swift-" + ImgixClient.VERSION + "&w=400"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
     
     func testBuildUrlWithMultipleParams() {
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 400, "flip": "v"])
-        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?w=400&flip=v"
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?flip=v&w=400"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }

--- a/ImgixSwiftTests/BuildUrlTests.swift
+++ b/ImgixSwiftTests/BuildUrlTests.swift
@@ -34,7 +34,7 @@ class BuildUrlTests: XCTestCase {
         client.includeLibraryParam = true
         
         let generatedUrl = client.buildUrl("1.jpg")
-        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?ixlib=swift-" + ImgixClient.VERSION
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?ixlib=swift-\(ImgixClient.VERSION)"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
@@ -57,7 +57,7 @@ class BuildUrlTests: XCTestCase {
         client.includeLibraryParam = true
         
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 400])
-        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?ixlib=swift-" + ImgixClient.VERSION + "&w=400"
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?ixlib=swift-\(ImgixClient.VERSION)&w=400"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
@@ -79,7 +79,7 @@ class BuildUrlTests: XCTestCase {
     func testBuildUrlWithMultipleParamsAndIncludeLibraryParamSorted() {
         client.includeLibraryParam = true
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 900, "h": 300, "fit": "crop", "crop": "entropy"])
-        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?crop=entropy&fit=crop&h=300" + "&ixlib=swift-" + ImgixClient.VERSION + "&w=900"
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?crop=entropy&fit=crop&h=300&ixlib=swift-\(ImgixClient.VERSION)&w=900"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }

--- a/ImgixSwiftTests/BuildUrlTests.swift
+++ b/ImgixSwiftTests/BuildUrlTests.swift
@@ -38,6 +38,13 @@ class BuildUrlTests: XCTestCase {
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
+
+    func testBuildUrlEmptyParams() {
+        let generatedUrl = client.buildUrl("1.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg"
+        
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
     
     func testBuildUrlWithOneParam() {
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 400])
@@ -58,6 +65,21 @@ class BuildUrlTests: XCTestCase {
     func testBuildUrlWithMultipleParams() {
         let generatedUrl = client.buildUrl("1.jpg", params: ["w": 400, "flip": "v"])
         let expectedUrl = "https://paulstraw.imgix.net/1.jpg?flip=v&w=400"
+        
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testBuildUrlWithMultipleParamsSorted() {
+        let generatedUrl = client.buildUrl("1.jpg", params: ["w": 900, "h": 300, "fit": "crop", "crop": "entropy"])
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?crop=entropy&fit=crop&h=300&w=900"
+        
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testBuildUrlWithMultipleParamsAndIncludeLibraryParamSorted() {
+        client.includeLibraryParam = true
+        let generatedUrl = client.buildUrl("1.jpg", params: ["w": 900, "h": 300, "fit": "crop", "crop": "entropy"])
+        let expectedUrl = "https://paulstraw.imgix.net/1.jpg?crop=entropy&fit=crop&h=300" + "&ixlib=swift-" + ImgixClient.VERSION + "&w=900"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ imgix is a real-time image processing service and CDN. It lets you edit images o
 
 The imgix Swift client is compatible with Swift 4.0.
 
-The lastest version compatible with Swift 3.0 is `0.3.0`.
+The lastest version compatible with Swift 3.0 is [`0.3.0`](https://github.com/imgix/imgix-swift/releases/tag/0.3.0).
 
 <a name="installation"></a>
 ## Installation

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can reconstruct existing URLs by using the `ImgixClient#reconstruct` method.
 let client = ImgixClient.init(host: "assets.imgix.net")
 let inputUrl = URL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=300")!
 
-client.buildUrl(inputUrl, params: [
+client.reconstruct(originalURL: inputUrl, params: [
   "h": 300,
   "fit": "crop"
 ]) // => https://paulstraw.imgix.net/pika.jpg?fit=crop&h=300&w=300

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The official imgix Swift client. Written in Swift, but plays nice with Objective
 
 imgix is a real-time image processing service and CDN. It lets you edit images on the fly by changing their URL query string parameters. That means you can crop and resize images without having to batch process them or store derivative versions. You can also automatically detect faces, overlay text and other images, and perform advanced compositing operations. To learn more about what you can do with imgix, check out our [site](https://imgix.com/) and [documentation](https://docs.imgix.com).
 
+* [Swift Version](#swift-version)
 * [Installation](#installation)
 * [Usage](#usage)
   * [Swift](#swift)
@@ -17,6 +18,12 @@ imgix is a real-time image processing service and CDN. It lets you edit images o
   * [URL Reconstruction](#url-reconstruction)
   * [What is the `ixlib` param?](#what-is-the-ixlib-param)
 
+<a name="swift-version"></a>
+## Swift Version
+
+The imgix Swift client is compatible with Swift 4.0.
+
+The lastest version compatible with Swift 3.0 is `0.3.0`.
 
 <a name="installation"></a>
 ## Installation
@@ -46,7 +53,7 @@ client.buildUrl("dog.jpg", params: [
   "w": 300,
   "h": 300,
   "fit": "crop"
-]) // => https://assets.imgix.net/dog.jpg?w=300&h=300&fit=crop
+]) // => https://assets.imgix.net/dog.jpg?fit=crop&h=300&w=300
 ```
 
 <a name="objective-c"></a>
@@ -69,7 +76,7 @@ ImgixClient *client = [[ImgixClient alloc] initWithHost:@"assets.imgix.net"];
   @"w": @300,
   @"h": @300,
   @"fit": @"crop",
-}]; // => https://assets.imgix.net/dog.jpg?w=300&h=300&fit=crop
+}]; // => https://assets.imgix.net/dog.jpg?fit=crop&h=300&w=300
 ```
 
 
@@ -110,7 +117,7 @@ client.buildUrl("dog.jpg", params: [
   "txtclr": "fff",
   "txtfit": "max",
   "txtsize": 50
-]) // => https://assets.imgix.net/dog.jpg?txtpad=50&txtalign=center%2Ctop&txt64=8J-QtiBQdXBweSE&txtclr=fff&txtfit=max&txtshad=10&w=640&txtfont64=QXZlbmlyIE5leHQgRGVtaSxCb2xk&txtsize=50
+]) // => https://assets.imgix.net/dog.jpg?txt64=8J-QtiBQdXBweSE&txtalign=center%2Ctop&txtclr=fff&txtfit=max&txtfont64=QXZlbmlyIE5leHQgRGVtaSxCb2xk&txtpad=50&txtshad=10&txtsize=50&w=640
 ```
 
 <a name="url-reconstruction"></a>
@@ -125,7 +132,7 @@ let inputUrl = URL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=300")!
 client.buildUrl(inputUrl, params: [
   "h": 300,
   "fit": "crop"
-]) // => https://paulstraw.imgix.net/pika.jpg?w=300&h=300&fit=crop
+]) // => https://paulstraw.imgix.net/pika.jpg?fit=crop&h=300&w=300
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The official imgix Swift client. Written in Swift, but plays nice with Objective
 
 imgix is a real-time image processing service and CDN. It lets you edit images on the fly by changing their URL query string parameters. That means you can crop and resize images without having to batch process them or store derivative versions. You can also automatically detect faces, overlay text and other images, and perform advanced compositing operations. To learn more about what you can do with imgix, check out our [site](https://imgix.com/) and [documentation](https://docs.imgix.com).
 
-* [Swift Version](#swift-version)
 * [Installation](#installation)
 * [Usage](#usage)
   * [Swift](#swift)
@@ -17,13 +16,6 @@ imgix is a real-time image processing service and CDN. It lets you edit images o
   * [Automatic Base64 Encoding](#automatic-base-64-encoding)
   * [URL Reconstruction](#url-reconstruction)
   * [What is the `ixlib` param?](#what-is-the-ixlib-param)
-
-<a name="swift-version"></a>
-## Swift Version
-
-The imgix Swift client is compatible with Swift 4.0.
-
-The lastest version compatible with Swift 3.0 is [`0.3.0`](https://github.com/imgix/imgix-swift/releases/tag/0.3.0).
 
 <a name="installation"></a>
 ## Installation
@@ -37,6 +29,10 @@ The lastest version compatible with Swift 3.0 is [`0.3.0`](https://github.com/im
 
 <a name="swift"></a>
 ### Swift
+
+The imgix Swift client is compatible with Swift 4.0.
+
+The lastest version compatible with Swift 3.0 is [`0.3.0`](https://github.com/imgix/imgix-swift/releases/tag/0.3.0).
 
 ``` swift
 // Import the framework

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,7 +124,7 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for key in params.allKeys.sorted() {
+        for key in params.allKeys.sorted(by: <) {
             let stringKey = String(describing: key)
             var stringVal = String(describing: params[val])
 

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -127,15 +127,18 @@ import Foundation
         let keys = params.allKeys.map { String(describing: $0) }
 
         for key in keys.sorted(by: {$0 < $1}) {
-            var stringVal = String(describing: params[key]!)
+            
+            if let val = params[key] {
+                var stringVal = String(describing: val)
 
-            if key.hasSuffix("64") {
-                stringVal = stringVal.ixEncode64()
+                if key.hasSuffix("64") {
+                    stringVal = stringVal.ixEncode64()
+                }
+
+                let queryItem = URLQueryItem.init(name: key, value: stringVal)
+
+                queryItems.append(queryItem)
             }
-
-            let queryItem = URLQueryItem.init(name: key, value: stringVal)
-
-            queryItems.append(queryItem)
         }
 
         return queryItems

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,11 +124,11 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        let keys: [String] = params.allKeys
+        let keys = params.allKeys.map { String(describing: $0) }
 
         for key in keys.sorted(by: {$0 < $1}) {
             let stringKey = String(describing: key)
-            var stringVal = String(describing: params[val])
+            var stringVal = String(describing: params[key]!)
 
             if stringKey.hasSuffix("64") {
                 stringVal = stringVal.ixEncode64()

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,7 +124,7 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for key in params.keys.sorted() {
+        for key in params.allKeys.sorted() {
             let stringKey = String(describing: key)
             var stringVal = String(describing: params[val])
 

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -127,14 +127,13 @@ import Foundation
         let keys = params.allKeys.map { String(describing: $0) }
 
         for key in keys.sorted(by: {$0 < $1}) {
-            let stringKey = String(describing: key)
             var stringVal = String(describing: params[key]!)
 
-            if stringKey.hasSuffix("64") {
+            if key.hasSuffix("64") {
                 stringVal = stringVal.ixEncode64()
             }
 
-            let queryItem = URLQueryItem.init(name: stringKey, value: stringVal)
+            let queryItem = URLQueryItem.init(name: key, value: stringVal)
 
             queryItems.append(queryItem)
         }

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,7 +124,7 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for key in params.allKeys.sorted(by: $0 < $1) {
+        for key in params.allKeys.sorted(by: {$0 < $1}) {
             let stringKey = String(describing: key)
             var stringVal = String(describing: params[val])
 

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,9 +124,9 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for (key, val) in params {
+        for key in params.keys.sorted() {
             let stringKey = String(describing: key)
-            var stringVal = String(describing: val)
+            var stringVal = String(describing: params[val])
 
             if stringKey.hasSuffix("64") {
                 stringVal = stringVal.ixEncode64()

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,7 +124,9 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for key in params.allKeys.sorted(by: {$0 < $1}) {
+        let keys: [String] = params.allKeys
+
+        for key in keys.sorted(by: {$0 < $1}) {
             let stringKey = String(describing: key)
             var stringVal = String(describing: params[val])
 

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -124,7 +124,7 @@ import Foundation
             params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        for key in params.allKeys.sorted(by: <) {
+        for key in params.allKeys.sorted(by: $0 < $1) {
             let stringKey = String(describing: key)
             var stringVal = String(describing: params[val])
 

--- a/Sources/ImgixClient.swift
+++ b/Sources/ImgixClient.swift
@@ -117,30 +117,29 @@ import Foundation
     }
 
     fileprivate func buildParams(_ params: NSDictionary) -> [URLQueryItem] {
-        let params: NSMutableDictionary = NSMutableDictionary.init(dictionary: params)
         var queryItems = [URLQueryItem]()
+        let queryParams: NSMutableDictionary = NSMutableDictionary.init(dictionary: params)
 
         if (includeLibraryParam) {
-            params.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
+            queryParams.setValue("swift-" + ImgixClient.VERSION, forKey: "ixlib")
         }
 
-        let keys = params.allKeys.map { String(describing: $0) }
-
+        let keys = queryParams.allKeys.map { String(describing: $0) }
+        
         for key in keys.sorted(by: {$0 < $1}) {
-            
-            if let val = params[key] {
+            if let val = queryParams[key] {
                 var stringVal = String(describing: val)
-
+                
                 if key.hasSuffix("64") {
                     stringVal = stringVal.ixEncode64()
                 }
 
                 let queryItem = URLQueryItem.init(name: key, value: stringVal)
-
+                
                 queryItems.append(queryItem)
             }
         }
-
+        
         return queryItems
     }
 


### PR DESCRIPTION
This fixes an issue with building URLs where the same parameter dictionaries may have outputted different URLs depending on their output order during iteration. To avoid this issue, I iterate through a sorted list of the dictionary keys in order to guarantee that building a URL with parameter dictionaries always outputs the same URL.