### PR TITLE
test: amend breaking reconstruct URL test cases

### DIFF
--- a/ImgixSwiftTests/ReconstructTests.swift
+++ b/ImgixSwiftTests/ReconstructTests.swift
@@ -25,7 +25,7 @@ class ReconstructTests: XCTestCase {
 
     func testReconstructUrlWithoutParams() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
         let expectedUrl = "https://paulstraw.imgix.net/pika.jpg"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -33,7 +33,7 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithSingleExistingParam() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
         let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=200"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -41,15 +41,15 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithMultipleExistingParams() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200&h=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
-        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=200&h=200"
-        
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
+        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?h=200&w=200"
+
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
     
     func testReconstructUrlWithoutParamsAndOneNewParam() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["w": 200])
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["w": 200])
         let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=200"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -57,7 +57,7 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithoutParamsAndMultipleNewParams() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["w": 200, "h": 200])
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["w": 200, "h": 200])
         let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?h=200&w=200"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -65,31 +65,31 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithSingleExistingParamAndOneNewParam() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["h": 200])
-        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=200&h=200"
-        
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["h": 200])
+        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?h=200&w=200"
+
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
     
     func testReconstructUrlWithMultipleExistingParamsAndOneNewParam() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200&h=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["fit": "crop"])
-        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=200&h=200&fit=crop"
-        
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["fit": "crop"])
+        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?fit=crop&h=200&w=200"
+
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
     
     func testReconstructUrlWithMultipleExistingParamsAndMultipleNewParams() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200&h=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["fit": "crop", "invert": true])
-        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?invert=1&w=200&h=200&fit=crop"
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["fit": "crop", "invert": true])
+        let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?fit=crop&h=200&invert=1&w=200"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
     
     func testReconstructUrlWithExistingParamOverriddenByNewParam() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net/pika.jpg?w=200")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL, params: ["w": 300])
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL, params: ["w": 300])
         let expectedUrl = "https://paulstraw.imgix.net/pika.jpg?w=300"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -97,7 +97,7 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithDifferentHostThanClient() {
         let inputUrl = NSURL.init(string: "https://faulstraw.imgix.net/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
         let expectedUrl = "https://faulstraw.imgix.net/pika.jpg"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -105,7 +105,7 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithDifferentSchemeThanClient() {
         let inputUrl = NSURL.init(string: "http://paulstraw.imgix.net/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
         let expectedUrl = "http://paulstraw.imgix.net/pika.jpg"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
@@ -113,7 +113,7 @@ class ReconstructTests: XCTestCase {
     
     func testReconstructUrlWithDifferentPortThanClient() {
         let inputUrl = NSURL.init(string: "https://paulstraw.imgix.net:8080/pika.jpg")
-        let generatedUrl = client.reconstruct(originalURL: inputUrl as! URL)
+        let generatedUrl = client.reconstruct(originalURL: inputUrl! as URL)
         let expectedUrl = "https://paulstraw.imgix.net:8080/pika.jpg"
         
         XCTAssert(generatedUrl.absoluteString == expectedUrl)


### PR DESCRIPTION
This PR amends a few broken tests in this package. It seems that the `ImgixClient` sorts parameters when constructing URLs, which prevented certain assertions from passing. There is also a slight syntax change made to alleviate an Xcode warning.