### PR TITLE
fix: remove residual objc interface header

### DIFF
--- a/ImgixSwift.podspec
+++ b/ImgixSwift.podspec
@@ -8,10 +8,6 @@ Pod::Spec.new do |s|
   s.authors = { "Paul Straw" => "paulstraw@paulstraw.com", "Sherwin Heydarbeygi" => "sherwin@imgix.com" }
   s.source = { :git => "https://github.com/imgix/imgix-swift.git", :tag => s.version }
 
-  s.xcconfig = {
-    "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ImgixSwift.h"
-  }
-
   s.requires_arc = true
   s.source_files = ["Sources/ImgixSwift/*.swift"]
 


### PR DESCRIPTION
Fixes #10 

This PR removes an errant Swift-to-ObjectiveC interface header definition that should have been removed in #21. The definition refers to a file that was removed in the last release, creating build issues for users who are importing this project via CocoaPods.