### PR TITLE
fix: percent-encode any path-invalid characters in URL path

### DIFF
--- a/Sources/ImgixSwift/ImgixClient.swift
+++ b/Sources/ImgixSwift/ImgixClient.swift
@@ -96,6 +96,9 @@ import Foundation
         if path.hasPrefix("http://") || path.hasPrefix("https://") {
             path = path.ixEncodeUriComponent()
         }
+        else {
+            path = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        }
 
         if !path.hasPrefix("/") {
             path = "/" + path

--- a/Tests/ImgixSwiftTests/BuildUrlTests.swift
+++ b/Tests/ImgixSwiftTests/BuildUrlTests.swift
@@ -102,4 +102,40 @@ class BuildUrlTests: XCTestCase {
 
         XCTAssert(generatedUrl.query == expectedQuery)
     }
+
+    func testUriEncodePath() {
+        let generatedUrl = client.buildUrl("ساندویچ.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testIgnoresLeadingSlash() {
+        let generatedUrl = client.buildUrl("/image.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/image.jpg"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testEncodesReservedCharacters() {
+        let generatedUrl = client.buildUrl(":?#.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/%3A%3F%23.jpg"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testEncodesUnsafeCharacters() {
+        let generatedUrl = client.buildUrl(" <>[]{}|^%\\.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25%5C.jpg"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
+    func testDoesNotEncodeValidPathCharacters() {
+        let generatedUrl = client.buildUrl("images/sub_directory-3/date,12.2020/bluehat.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/images/sub_directory-3/date,12.2020/bluehat.jpg"
+
+        print(generatedUrl)
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
 }

--- a/Tests/ImgixSwiftTests/WebProxyTests.swift
+++ b/Tests/ImgixSwiftTests/WebProxyTests.swift
@@ -37,4 +37,12 @@ class WebProxyTests: XCTestCase {
 
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
+
+    func testEscapesEncodedPath() {
+        let generatedUrl = client.buildUrl("http://files.paulstraw.com/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg")
+        let expectedUrl = "https://imgix-library-web-proxy-test-source.imgix.net/" +
+            "http%3A%2F%2Ffiles.paulstraw.com%2F%25D8%25B3%25D8%25A7%25D9%2586%25D8%25AF%25D9%2588%25DB%258C%25DA%2586.jpg?s=aaecb132495341b884a0d8e35a51ae11"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
 }


### PR DESCRIPTION
This PR fixes a gap in the `ImgixClient` path-handling logic where it did not properly encode path-illegal characters.

Fixes #25 