### PR TITLE
chore: change refs of master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 [![CocoaPods](https://img.shields.io/cocoapods/v/ImgixSwift.svg)](https://cocoapods.org/pods/ImgixSwift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Build Status](https://travis-ci.org/imgix/imgix-swift.svg?branch=master)](https://travis-ci.org/imgix/imgix-swift)
+[![Build Status](https://travis-ci.org/imgix/imgix-swift.svg?branch=main)](https://travis-ci.org/imgix/imgix-swift)
 ![Supported Platforms](https://img.shields.io/cocoapods/p/ImgixSwift.svg)
-[![License](https://img.shields.io/github/license/imgix/imgix-swift)](https://github.com/imgix/imgix-swift/blob/master/LICENSE.md)
+[![License](https://img.shields.io/github/license/imgix/imgix-swift)](https://github.com/imgix/imgix-swift/blob/main/LICENSE.md)
 
 ---
 <!-- /ix-docs-ignore -->


### PR DESCRIPTION
This PR changes any references from the master branch to the main branch, now that it is the default.