### PR TITLE
ci: migrate to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+# For a detailed guide to building and testing on iOS, read the docs:
+# https://circleci.com/docs/2.0/testing-ios/
+
+version: 2.1
+
+jobs:
+  build:
+
+    macos:
+      xcode: 11.3.0 # Specify the Xcode version to use
+
+    steps:
+      - checkout
+      - run: bundle install --jobs=3 --retry=3 # Install dependencies
+      - run: bundle exec rake test # Run tests using Rake
+
+      # Collect XML test results data to show in the UI, and save the same XML
+      # files under test-results folder in the Artifacts tab
+      - store_test_results:
+          path: test_output
+      - store_artifacts:
+          path: test_output
+          destination: scan-output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
 
     steps:
       - checkout
+      - run: bundle update --bundler
       - run: bundle install --jobs=3 --retry=3 # Install dependencies
       - run: bundle exec rake test # Run tests using Rake
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
 
     macos:
-      xcode: 11.3.0 # Specify the Xcode version to use
+      xcode: 12.3.0 # Specify the Xcode version to use
 
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: objective-c
-osx_image: xcode11.3
-install:
-  - bundle install --jobs=3 --retry=3
-script: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,4 +16,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.12.5
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CocoaPods](https://img.shields.io/cocoapods/v/ImgixSwift.svg)](https://cocoapods.org/pods/ImgixSwift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Build Status](https://travis-ci.com/imgix/imgix-swift.svg?branch=main)](https://travis-ci.com/imgix/imgix-swift)
+![Build Status](https://img.shields.io/circleci/build/github/imgix/imgix-swift)
 ![Supported Platforms](https://img.shields.io/cocoapods/p/ImgixSwift.svg)
 [![License](https://img.shields.io/github/license/imgix/imgix-swift)](https://github.com/imgix/imgix-swift/blob/main/LICENSE.md)
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,28 @@ desc 'Run the tests'
 task :test do
   require_binary 'xcodebuild', 'brew install xcodebuild'
   require_binary 'xcpretty', 'bundle install'
-  sh 'xcodebuild test -project imgix-swift.xcodeproj -scheme ImgixSwift-iOS -destination \'OS=12.0,name=iPhone 8\' -sdk \'iphonesimulator\' -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}'
+  sh '''
+    xcodebuild test \
+      -project imgix-swift.xcodeproj \
+      -scheme ImgixSwift-iOS \
+      -destination \'OS=14.3,name=iPhone 11\' \
+      -sdk \'iphonesimulator\' \
+      -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}
+  '''
+  sh '''
+    xcodebuild test \
+    -project imgix-swift.xcodeproj \
+    -scheme ImgixSwift-macOS \
+    -destination \'platform=OS X,arch=x86_64\' \
+    -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}
+  '''
+  sh '''
+    xcodebuild test \
+    -project imgix-swift.xcodeproj \
+    -scheme ImgixSwift-tvOS \
+    -destination \'OS=14.3,name=Apple TV\' \
+    -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}
+  '''
 end
 
 task :default => :test


### PR DESCRIPTION
Migrates this project over to CircleCI. This PR also strengthens the tests adding a separate execution for each scheme that imgix-swift is built for (`macOS`, `iOS`, and `tvOS`).

Addition context: this migration did not work immediately because the previous tests ran on a version of iOS no longer supported by `xcodebuild`. For now, I have adjusted the tests to use supported versions + devices, but it would be worth further investigating in the future how to config these tests to be more robust.