### PR TITLE
fix(buildUrl): path encoding

### DIFF
--- a/Sources/ImgixSwift/ImgixClient.swift
+++ b/Sources/ImgixSwift/ImgixClient.swift
@@ -95,9 +95,8 @@ import Foundation
 
         if path.hasPrefix("http://") || path.hasPrefix("https://") {
             path = path.ixEncodeUriComponent()
-        }
-        else {
-            path = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        } else {
+            path = path.ixEncodeUri()
         }
 
         if !path.hasPrefix("/") {

--- a/Sources/ImgixSwift/String+ImgixSwift.swift
+++ b/Sources/ImgixSwift/String+ImgixSwift.swift
@@ -15,6 +15,12 @@ extension String {
         return charSet
     }()
 
+    static var ixEncodeUriCharSet: CharacterSet = {
+        var charSet = CharacterSet.urlPathAllowed
+        charSet.remove(charactersIn: "#?:+")
+        return charSet
+    }()
+
     func ixEncode64() -> String {
         let strData = self.data(using: String.Encoding.utf8)
 
@@ -31,6 +37,10 @@ extension String {
 
     func ixEncodeUriComponent() -> String {
         return self.addingPercentEncoding(withAllowedCharacters: String.ixEncodeUriComponentCharSet)!
+    }
+
+    func ixEncodeUri() -> String {
+        return self.addingPercentEncoding(withAllowedCharacters: String.ixEncodeUriCharSet)!
     }
 
     func ixMd5() -> String {

--- a/Tests/ImgixSwiftTests/BuildUrlTests.swift
+++ b/Tests/ImgixSwiftTests/BuildUrlTests.swift
@@ -131,6 +131,13 @@ class BuildUrlTests: XCTestCase {
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }
 
+    func testEncodesUnicode() {
+        let generatedUrl = client.buildUrl("/example/I cannøt belîév∑ it wors! 😱.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/example/I%20cann%C3%B8t%20bel%C3%AE%C3%A9v%E2%88%91%20it%20wor%EF%A3%BFs!%20%F0%9F%98%B1.jpg"
+
+        XCTAssert(generatedUrl.absoluteString == expectedUrl)
+    }
+
     func testDoesNotEncodeValidPathCharacters() {
         let generatedUrl = client.buildUrl("images/sub_directory-3/date,12.2020/bluehat.jpg", params: [:])
         let expectedUrl = "https://paulstraw.imgix.net/images/sub_directory-3/date,12.2020/bluehat.jpg"

--- a/Tests/ImgixSwiftTests/BuildUrlTests.swift
+++ b/Tests/ImgixSwiftTests/BuildUrlTests.swift
@@ -118,8 +118,8 @@ class BuildUrlTests: XCTestCase {
     }
 
     func testEncodesReservedCharacters() {
-        let generatedUrl = client.buildUrl(":?#.jpg", params: [:])
-        let expectedUrl = "https://paulstraw.imgix.net/%3A%3F%23.jpg"
+        let generatedUrl = client.buildUrl("&$+,:;=?@#.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/&$%2B,%3A%3B=%3F@%23.jpg"
 
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }


### PR DESCRIPTION
# Description

This PR ensures that `+` get encoded properly by the `buildUrl` method and adds relevant tests.