### PR TITLE
test: adjust encoding case to match same test in other projects

### DIFF
--- a/Tests/ImgixSwiftTests/BuildUrlTests.swift
+++ b/Tests/ImgixSwiftTests/BuildUrlTests.swift
@@ -125,8 +125,8 @@ class BuildUrlTests: XCTestCase {
     }
 
     func testEncodesUnsafeCharacters() {
-        let generatedUrl = client.buildUrl(" <>[]{}|^%\\.jpg", params: [:])
-        let expectedUrl = "https://paulstraw.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25%5C.jpg"
+        let generatedUrl = client.buildUrl(" <>[]{}|\\^%.jpg", params: [:])
+        let expectedUrl = "https://paulstraw.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
 
         XCTAssert(generatedUrl.absoluteString == expectedUrl)
     }


### PR DESCRIPTION
This PR slightly adjusts one of the encoding test cases to identically match the same test in our other [SDK repos](https://github.com/imgix/js-core/pull/282/files#diff-2fe4ef2723550a8dcc53ce991612647a0837843b049a6b999604983454429e0eR17).