### PR TITLE
ci: version bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,8 @@ version: 2.1
 
 jobs:
   build:
-
     macos:
-      xcode: 12.3.0 # Specify the Xcode version to use
+      xcode: 12.5.1 # Specify the Xcode version to use
 
     steps:
       - checkout

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :test do
     xcodebuild test \
       -project imgix-swift.xcodeproj \
       -scheme ImgixSwift-iOS \
-      -destination \'OS=14.3,name=iPhone 11\' \
+      -destination \'OS=14.5,name=iPhone 11\' \
       -sdk \'iphonesimulator\' \
       -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}
   '''

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :test do
     xcodebuild test \
     -project imgix-swift.xcodeproj \
     -scheme ImgixSwift-tvOS \
-    -destination \'OS=14.3,name=Apple TV\' \
+    -destination \'OS=14.5,name=Apple TV\' \
     -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}
   '''
 end


### PR DESCRIPTION
The Xcode and OS versions in our CI Pipeline were no longer supported; this PR bumps these versions back up to date.